### PR TITLE
Edge Cases

### DIFF
--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -18,7 +18,11 @@ class MerchantDiscountsController < ApplicationController
     merchant = Merchant.find(params[:merchant_id])
     discount = Discount.find(params[:id])
     discount.update(discount_params)
-    redirect_to "/merchants/#{merchant.id}/discounts/#{discount.id}",  notice: "Discount Successfully Updated"
+    if discount.save
+      redirect_to "/merchants/#{merchant.id}/discounts/#{discount.id}",  notice: "Discount Successfully Updated"
+    else
+      redirect_to "/merchants/#{merchant.id}/discounts/#{discount.id}/edit", alert: "Your discount rate is incorrect"
+    end
   end
 
   def new
@@ -29,7 +33,11 @@ class MerchantDiscountsController < ApplicationController
   def create
     merchant = Merchant.find(params[:merchant_id])
     discount = merchant.discounts.create(discount_params)
-    redirect_to "/merchants/#{merchant.id}/discounts"
+    if discount.save
+      redirect_to "/merchants/#{merchant.id}/discounts"
+    else
+      redirect_to "/merchants/#{merchant.id}/discounts/new", alert: "Your discount rate is incorrect"
+    end
   end
 
   def destroy

--- a/app/models/discount.rb
+++ b/app/models/discount.rb
@@ -1,3 +1,5 @@
 class Discount < ApplicationRecord
   belongs_to :merchant
+
+  validates :discount_rate, numericality: { less_than: 0.71 }
 end

--- a/app/views/merchant_discounts/edit.html.erb
+++ b/app/views/merchant_discounts/edit.html.erb
@@ -3,7 +3,7 @@
 <%= form_with model: [@merchant, @discount] , local: true do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name, :value => @discount.name %>
-  <%= form.label :discount_rate, "Discount Rate(as a decimal ex: 0.30 = 30%):" %>
+  <%= form.label :discount_rate, "Discount Rate that is less than 71%(as a decimal ex: 30% = 0.30):" %>
   <%= form.text_field :discount_rate, :value => @discount.discount_rate %>
   <%= form.label :threshold_quantity, "Threshold Quantity:" %>
   <%= form.text_field :threshold_quantity, :value => @discount.threshold_quantity %>

--- a/app/views/merchant_discounts/new.html.erb
+++ b/app/views/merchant_discounts/new.html.erb
@@ -3,7 +3,7 @@
 <%= form_with model: [@merchant, @discount] , local: true do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name %>
-  <%= form.label :discount_rate, "Discount Rate(as a decimal ex: 0.30 = 30%):" %>
+  <%= form.label :discount_rate, "Discount Rate that is less than 71%(as a decimal ex: 30% = 0.30):" %>
   <%= form.text_field :discount_rate %>
   <%= form.label :threshold_quantity, "Threshold Quantity:" %>
   <%= form.text_field :threshold_quantity %>

--- a/spec/features/merchants/discounts/edit_spec.rb
+++ b/spec/features/merchants/discounts/edit_spec.rb
@@ -17,4 +17,19 @@ RSpec.describe "Merchant Discounts Edit page" do
     #checking for flash message
     expect(page).to have_content("Discount Successfully Updated")
   end
+
+  it 'returns an error message if the wrong discount rate is entered' do
+    merchant = create(:merchant)
+    discount = create(:discount, merchant: merchant, discount_rate: 0.3, threshold_quantity: 30, name: "30 For 30")
+
+    visit "/merchants/#{merchant.id}/discounts/#{discount.id}"
+    click_on "Update #{discount.name}"
+    expect(current_path).to eq("/merchants/#{merchant.id}/discounts/#{discount.id}/edit")
+    fill_in 'discount_discount_rate', with: 0.8
+    click_on 'Update Discount'
+    expect(current_path).to eq("/merchants/#{merchant.id}/discounts/#{discount.id}/edit")
+    #checking for flash message
+    expect(page).to have_content("Your discount rate is incorrect")
+  end
+
 end

--- a/spec/features/merchants/discounts/new_spec.rb
+++ b/spec/features/merchants/discounts/new_spec.rb
@@ -14,4 +14,19 @@ RSpec.describe "Merchant Discount New page" do
     expect(current_path).to eq("/merchants/#{merchant.id}/discounts")
     expect(page).to have_link("20 For 20")
   end
+
+  it 'returns an error message if the wrong discount rate is entered' do
+    merchant = create(:merchant)
+
+    visit "/merchants/#{merchant.id}/discounts/new"
+
+    expect(page).to have_content("Add a new discount")
+    fill_in "discount_name", with: "20 For 20"
+    fill_in "discount_discount_rate", with: 0.80
+    fill_in "discount_threshold_quantity", with: 20
+    click_on "Create Discount"
+    expect(current_path).to eq("/merchants/#{merchant.id}/discounts/new")
+    #checking for flash message
+    expect(page).to have_content("Your discount rate is incorrect")
+  end
 end

--- a/spec/models/discount_spec.rb
+++ b/spec/models/discount_spec.rb
@@ -4,4 +4,8 @@ RSpec.describe Discount, type: :model do
   describe 'associations' do
     it { should belong_to(:merchant) }
   end
+
+  describe 'validations' do
+    it { should validate_numericality_of(:discount_rate) }
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -93,6 +93,25 @@ RSpec.describe Invoice, type: :model do
         discount_1 = create(:discount, merchant: merchant_1, threshold_quantity: 10, discount_rate: 0.1)
         expect(invoice_1.discounted_revenue(merchant_1)).to eq(12000)
       end
+
+      it 'returns 0 if the merchant has no discounts' do
+        merchant_1 = create(:merchant)
+        invoice_1 = create(:invoice)
+        item_1 = create(:item_with_invoices, merchant: merchant_1, invoices: [invoice_1], invoice_item_unit_price: 10000, invoice_item_quantity: 12)
+        transaction = create(:transaction, invoice: invoice_1, result: 0)
+
+        expect(invoice_1.discounted_revenue(merchant_1)).to eq(0)
+      end
+
+      it 'returns 0 if the item quantity does not meet the discounts threshold' do
+        merchant_1 = create(:merchant)
+        invoice_1 = create(:invoice)
+        item_1 = create(:item_with_invoices, merchant: merchant_1, invoices: [invoice_1], invoice_item_unit_price: 10000, invoice_item_quantity: 9)
+        transaction = create(:transaction, invoice: invoice_1, result: 0)
+        discount_1 = create(:discount, merchant: merchant_1, threshold_quantity: 10, discount_rate: 0.1)
+        expect(invoice_1.discounted_revenue(merchant_1)).to eq(0)
+      end
+
     end
 
     describe '#admin_discounted_revenue' do


### PR DESCRIPTION
- If merchant doesn't have any discounts
- If item quantity does not meet the discount threshold
- If merchant inputs a discount rate greater than 71% the form refreshes
   - Edit and New Views
   - Also added a flash notification to alert the merchant of their mistake
- If item qualifies for a better discount then the better discount is used(already a test in place) 